### PR TITLE
Add ac_admin_password for secrets repository

### DIFF
--- a/roles/ansible_control/tasks/install.yml
+++ b/roles/ansible_control/tasks/install.yml
@@ -50,6 +50,6 @@
 
 - name: Checkout secrets repository into home of interactive_user # noqa: latest[git]
   ansible.builtin.command:
-    cmd: "sshpass -p <password> git clone {{ git_repo_secrets }} {{ interactive_home }}/{{ repo_secrets_dir }}"
+    cmd: "sshpass -p {{ ac_admin_password }} git clone {{ git_repo_secrets }} {{ interactive_home }}/{{ repo_secrets_dir }}"
   become_user: "{{ interactive_user }}"
   changed_when: true

--- a/roles/ansible_control/tasks/main.yml
+++ b/roles/ansible_control/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 # tasks file for ansible_control
+- name: Include vaulted password file
+  ansible.builtin.include_vars:
+    file: ../home/ansible-vault/ansible-control-vars.yml
+
 - name: Include install tasks when relevant
   ansible.builtin.import_tasks: install.yml
   when: action_install


### PR DESCRIPTION
This makes the ansible_control role less dependent on hardcoded values.
In the secret repository, there should be a file ansible-control-vars.yaml, in the folder ./ansible-vault

This will ensure the parametrized use of these vars in the role.